### PR TITLE
Fix version display, direct paste, and add quick paste shortcuts

### DIFF
--- a/Scripts/bundle-app.sh
+++ b/Scripts/bundle-app.sh
@@ -66,9 +66,9 @@ cat > "$CONTENTS_DIR/Info.plist" << 'EOF'
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.2.2</string>
+    <string>1.3.1</string>
     <key>CFBundleVersion</key>
-    <string>6</string>
+    <string>7</string>
     <key>LSMinimumSystemVersion</key>
     <string>14.0</string>
     <key>LSUIElement</key>

--- a/Sources/DodoClip/App/AppDelegate.swift
+++ b/Sources/DodoClip/App/AppDelegate.swift
@@ -97,6 +97,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func showPopover() {
         guard let button = statusItem?.button else { return }
+        // Remember the frontmost app so we can paste back to it
+        pasteService.savePreviousApp()
 
         let popover = NSPopover()
         popover.contentSize = NSSize(
@@ -217,6 +219,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     private func showBottomPanel() {
+        // Remember the frontmost app so we can paste back to it
+        pasteService.savePreviousApp()
         updatePanelContent()
         clipboardMonitor.resetNewClipCount()
         panelController?.show()
@@ -239,6 +243,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         hotkeyManager.onPasteStackHotkey = { [weak self] in
             self?.activatePasteStack()
+        }
+
+        hotkeyManager.onQuickPasteHotkey = { [weak self] index in
+            self?.quickPaste(index: index)
         }
     }
 
@@ -288,6 +296,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func openItem(_ item: ClipItem) {
         pasteService.open(item)
+    }
+
+    // MARK: - Quick Paste
+
+    private func quickPaste(index: Int) {
+        let items = clipboardMonitor.items
+        guard index < items.count else { return }
+        pasteService.savePreviousApp()
+        pasteService.paste(items[index])
     }
 
     // MARK: - Paste Stack

--- a/Sources/DodoClip/App/DodoClipApp.swift
+++ b/Sources/DodoClip/App/DodoClipApp.swift
@@ -152,6 +152,14 @@ struct ShortcutsSettingsTab: View {
                         .font(.system(.body, design: .monospaced))
                         .foregroundColor(.secondary)
                 }
+
+                HStack {
+                    Text("Quick paste (1st–9th item)")
+                    Spacer()
+                    Text("⌃⌘1–9")
+                        .font(.system(.body, design: .monospaced))
+                        .foregroundColor(.secondary)
+                }
             }
         }
         .formStyle(.grouped)

--- a/Sources/DodoClip/Services/HotkeyManager.swift
+++ b/Sources/DodoClip/Services/HotkeyManager.swift
@@ -10,14 +10,19 @@ final class HotkeyManager: ObservableObject {
     // Hotkey references
     private var panelHotkeyRef: EventHotKeyRef?
     private var pasteStackHotkeyRef: EventHotKeyRef?
+    private var quickPasteHotkeyRefs: [EventHotKeyRef?] = Array(repeating: nil, count: 9)
 
     // Callbacks
     var onPanelHotkey: (() -> Void)?
     var onPasteStackHotkey: (() -> Void)?
+    /// Called with the quick paste index (0-8) corresponding to Cmd+1 through Cmd+9
+    var onQuickPasteHotkey: ((Int) -> Void)?
 
     // Hotkey IDs
     private let panelHotkeyID: UInt32 = 1
     private let pasteStackHotkeyID: UInt32 = 2
+    // Quick paste IDs: 10-18 for Cmd+1 through Cmd+9
+    private let quickPasteBaseID: UInt32 = 10
 
     private init() {}
 
@@ -29,6 +34,9 @@ final class HotkeyManager: ObservableObject {
 
         // ⇧⌘C for paste stack
         registerPasteStackHotkey(keyCode: UInt32(kVK_ANSI_C), modifiers: shiftCmdModifiers)
+
+        // ⌃⌘1-9 for quick paste
+        registerQuickPasteHotkeys()
     }
 
     private var shiftCmdModifiers: UInt32 {
@@ -81,6 +89,48 @@ final class HotkeyManager: ObservableObject {
         }
     }
 
+    // Key codes for number keys 1-9
+    private static let numberKeyCodes: [UInt32] = [
+        UInt32(kVK_ANSI_1), UInt32(kVK_ANSI_2), UInt32(kVK_ANSI_3),
+        UInt32(kVK_ANSI_4), UInt32(kVK_ANSI_5), UInt32(kVK_ANSI_6),
+        UInt32(kVK_ANSI_7), UInt32(kVK_ANSI_8), UInt32(kVK_ANSI_9)
+    ]
+
+    func registerQuickPasteHotkeys() {
+        unregisterQuickPasteHotkeys()
+
+        let modifiers = UInt32(controlKey | cmdKey)
+
+        for i in 0..<9 {
+            var hotkeyID = EventHotKeyID(signature: OSType(0x444F444F), id: quickPasteBaseID + UInt32(i))
+            var hotkeyRef: EventHotKeyRef?
+
+            let status = RegisterEventHotKey(
+                Self.numberKeyCodes[i],
+                modifiers,
+                hotkeyID,
+                GetApplicationEventTarget(),
+                0,
+                &hotkeyRef
+            )
+
+            if status == noErr {
+                quickPasteHotkeyRefs[i] = hotkeyRef
+            } else {
+                print("Failed to register quick paste hotkey Ctrl+Cmd+\(i + 1): \(status)")
+            }
+        }
+    }
+
+    func unregisterQuickPasteHotkeys() {
+        for i in 0..<9 {
+            if let ref = quickPasteHotkeyRefs[i] {
+                UnregisterEventHotKey(ref)
+                quickPasteHotkeyRefs[i] = nil
+            }
+        }
+    }
+
     // MARK: - Unregistration
 
     func unregisterPanelHotkey() {
@@ -100,6 +150,7 @@ final class HotkeyManager: ObservableObject {
     func unregisterAll() {
         unregisterPanelHotkey()
         unregisterPasteStackHotkey()
+        unregisterQuickPasteHotkeys()
     }
 
     // MARK: - Event Handling
@@ -140,6 +191,9 @@ final class HotkeyManager: ObservableObject {
             onPanelHotkey?()
         case pasteStackHotkeyID:
             onPasteStackHotkey?()
+        case quickPasteBaseID...(quickPasteBaseID + 8):
+            let index = Int(id - quickPasteBaseID)
+            onQuickPasteHotkey?(index)
         default:
             break
         }

--- a/Sources/DodoClip/Services/PasteService.swift
+++ b/Sources/DodoClip/Services/PasteService.swift
@@ -6,7 +6,19 @@ import Carbon
 final class PasteService {
     static let shared = PasteService()
 
+    /// The app that was frontmost before DodoClip's panel appeared
+    private var previousApp: NSRunningApplication?
+
     private init() {}
+
+    /// Remember the currently frontmost app so we can restore focus before pasting
+    func savePreviousApp() {
+        let frontmost = NSWorkspace.shared.frontmostApplication
+        // Don't save DodoClip itself
+        if frontmost?.bundleIdentifier != Bundle.main.bundleIdentifier {
+            previousApp = frontmost
+        }
+    }
 
     // MARK: - Paste Actions
 
@@ -103,8 +115,13 @@ final class PasteService {
     // MARK: - Simulate Paste
 
     private func simulatePaste() {
-        // Small delay to ensure pasteboard is ready
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+        // Restore focus to the previous app before sending the keystroke
+        if let app = previousApp {
+            app.activate()
+        }
+
+        // Delay to ensure the target app is focused and pasteboard is ready
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             self.sendPasteKeystroke()
         }
     }


### PR DESCRIPTION
## Summary

- **Fix #17** — Updated hardcoded version string in `bundle-app.sh` from `1.2.2` to `1.3.1` so the About page shows the correct version
- **Fix #16** — Restored focus to the previous app before sending the synthetic Cmd+V keystroke, so paste actually lands in the target app instead of DodoClip's panel
- **Fix #11** — Added Ctrl+Cmd+1-9 global hotkeys for quick pasting the 1st–9th clipboard item directly (used Ctrl+Cmd instead of plain Cmd to avoid conflicts with system shortcuts)

## Test plan

- [ ] Build the app with `bundle-app.sh` and verify About page shows version 1.3.1
- [ ] Open panel (Shift+Cmd+V), click a clip item, verify it pastes into the previously focused app
- [ ] Open popover from menu bar, click a clip item, verify it pastes into the previously focused app
- [ ] Copy several items, then press Ctrl+Cmd+1 through Ctrl+Cmd+3, verify each pastes the correct item
- [ ] Verify Ctrl+Cmd+1-9 does nothing gracefully when fewer items exist than the number pressed
- [ ] Check Shortcuts settings tab shows the new "Quick paste (1st–9th item)" entry