### PR TITLE
Add a prompt to request privacy permissions on launch

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -57,6 +57,13 @@ Nach der Installation führe diesen Befehl aus, um die App zu öffnen:
 xattr -cr /Applications/DodoClip.app
 ```
 
+Erteile DodoClip danach in diesen macOS-Datenschutzlisten die erforderlichen Berechtigungen, damit globales Einfügen funktioniert:
+
+- `Systemeinstellungen > Datenschutz & Sicherheit > Bedienungshilfen`
+- `Systemeinstellungen > Datenschutz & Sicherheit > Eingabekontrolle`, falls DodoClip dort auf deinem System angezeigt wird
+
+Wenn DodoClip zwar startet, aber beim Auswählen eines Eintrags nur die Zwischenablage aktualisiert und nichts in die vorherige App einfügt, entferne DodoClip aus genau diesen Listen, füge die App erneut hinzu und starte sie neu. Auf manchen macOS-Systemen ist diese Aktualisierung nach einer Installation oder einem Update erforderlich.
+
 ## Aus dem Quellcode bauen
 
 1. Repository klonen:

--- a/README.es.md
+++ b/README.es.md
@@ -57,6 +57,13 @@ Después de instalar, ejecuta este comando para permitir que la app se abra:
 xattr -cr /Applications/DodoClip.app
 ```
 
+Después, concede permiso a DodoClip en estas listas de privacidad de macOS para que el pegado global funcione:
+
+- `Configuración del Sistema > Privacidad y seguridad > Accesibilidad`
+- `Configuración del Sistema > Privacidad y seguridad > Monitorización de entrada` si DodoClip aparece en esa lista en tu sistema
+
+Si DodoClip se abre pero al seleccionar un elemento solo actualiza el portapapeles y no pega en la app anterior, elimina DodoClip de esas mismas listas, añádelo de nuevo y vuelve a abrir la app. En algunas configuraciones de macOS este reinicio de permisos es necesario después de instalar o actualizar la aplicación.
+
 ## Compilar desde el código fuente
 
 1. Clona el repositorio:

--- a/README.fr.md
+++ b/README.fr.md
@@ -57,6 +57,13 @@ Après l'installation, exécutez cette commande pour autoriser l'ouverture de l'
 xattr -cr /Applications/DodoClip.app
 ```
 
+Accordez ensuite à DodoClip les autorisations nécessaires dans ces listes macOS pour que le collage global fonctionne :
+
+- `Réglages Système > Confidentialité et sécurité > Accessibilité`
+- `Réglages Système > Confidentialité et sécurité > Surveillance de l'entrée` si DodoClip apparaît dans cette liste sur votre système
+
+Si DodoClip s'ouvre mais que la sélection d'un élément met seulement à jour le presse-papiers sans coller dans l'application précédente, supprimez DodoClip de ces mêmes listes, ajoutez-le de nouveau, puis relancez l'app. Sur certaines configurations macOS, cette réinitialisation est nécessaire après une installation ou une mise à jour.
+
 ## Compilation depuis les sources
 
 1. Clonez le dépôt :

--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ After installing, run this command to allow the app to open:
 xattr -cr /Applications/DodoClip.app
 ```
 
+Then grant DodoClip permission in these macOS privacy lists so global paste works:
+
+- `System Settings > Privacy & Security > Accessibility`
+- `System Settings > Privacy & Security > Input Monitoring` if DodoClip appears there on your system
+
+If DodoClip opens but selecting an item only updates the clipboard and does not paste into the previous app, remove DodoClip from those same lists, add it again, and reopen the app. On some macOS setups this refresh is required after installing or updating the app.
+
 ## Building from Source
 
 1. Clone the repository:
@@ -101,6 +108,8 @@ xattr -cr /Applications/DodoClip.app
 ```
 
 Then open DodoClip again.
+
+For global paste to work reliably, enable DodoClip in `System Settings > Privacy & Security > Accessibility` and in `System Settings > Privacy & Security > Input Monitoring` if DodoClip appears there on your system. If paste still only updates the clipboard after an install or update, remove DodoClip from those lists, add it again, and reopen the app.
 
 ### I double-clicked the app but nothing happened
 

--- a/README.tr.md
+++ b/README.tr.md
@@ -57,6 +57,13 @@ Kurulumdan sonra uygulamayı açmak için bu komutu çalıştırın:
 xattr -cr /Applications/DodoClip.app
 ```
 
+Ardından global yapıştırmanın çalışması için DodoClip'e macOS'ta şu gizlilik listelerinde izin verin:
+
+- `Sistem Ayarları > Gizlilik ve Güvenlik > Erişilebilirlik`
+- `Sistem Ayarları > Gizlilik ve Güvenlik > Giriş İzleme`, eğer DodoClip sisteminizde bu listede görünüyorsa
+
+DodoClip açılıyor ama bir öğe seçildiğinde sadece pano güncelleniyor ve önceki uygulamaya yapıştırılmıyorsa, DodoClip'i bu listelerden kaldırın, yeniden ekleyin ve uygulamayı tekrar açın. Bazı macOS kurulumlarında bu yenileme kurulum veya güncellemeden sonra gerekli oluyor.
+
 ## Kaynak Koddan Derleme
 
 1. Depoyu klonlayın:

--- a/Sources/DodoClip/App/AppDelegate.swift
+++ b/Sources/DodoClip/App/AppDelegate.swift
@@ -2,6 +2,12 @@ import AppKit
 import SwiftUI
 import Combine
 
+enum PanelHotkeyAction: Equatable {
+    case completeFirstRun
+    case hidePanel
+    case showPanel
+}
+
 /// Main application delegate managing menu bar and panel
 @MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate {
@@ -13,6 +19,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private let clipboardMonitor = ClipboardMonitor.shared
     private let hotkeyManager = HotkeyManager.shared
     private let pasteService = PasteService.shared
+    private let permissionsService = PermissionsService.shared
 
     // Observers
     private var cancellables = Set<AnyCancellable>()
@@ -39,6 +46,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Perform auto-cleanup if enabled
         clipboardMonitor.checkAutoCleanup()
+
+        promptForRequiredPermissionsIfNeeded()
     }
 
     func applicationWillTerminate(_ notification: Notification) {
@@ -110,12 +119,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         let menuBarView = MenuBarPopoverView(
             onPaste: { [weak self] item in
-                self?.pasteItem(item)
-                self?.popover?.performClose(nil)
+                self?.dismissPopoverThen {
+                    self?.pasteItem(item)
+                }
             },
             onPastePlainText: { [weak self] item in
-                self?.pasteItemPlainText(item)
-                self?.popover?.performClose(nil)
+                self?.dismissPopoverThen {
+                    self?.pasteItemPlainText(item)
+                }
             },
             onCopy: { [weak self] item in
                 self?.copyItem(item)
@@ -188,16 +199,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             collections: Collection.defaultCollections,
             isCompact: false,
             onPaste: { [weak self] item in
-                self?.pasteItem(item)
-                self?.panelController?.hide()
+                self?.dismissPanelThen {
+                    self?.pasteItem(item)
+                }
             },
             onPastePlainText: { [weak self] item in
-                self?.pasteItemPlainText(item)
-                self?.panelController?.hide()
+                self?.dismissPanelThen {
+                    self?.pasteItemPlainText(item)
+                }
             },
             onPasteMultiple: { [weak self] items in
-                self?.pasteItems(items)
-                self?.panelController?.hide()
+                self?.dismissPanelThen {
+                    self?.pasteItems(items)
+                }
             },
             onPin: { [weak self] item in
                 self?.togglePin(item)
@@ -212,6 +226,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 self?.panelController?.hide()
             }
         )
+    }
+
+    private func dismissPanelThen(_ action: @escaping () -> Void) {
+        panelController?.hide(completion: action)
+    }
+
+    private func dismissPopoverThen(_ action: @escaping () -> Void) {
+        popover?.performClose(nil)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05, execute: action)
     }
 
     @objc private func showBottomPanelAction() {
@@ -233,21 +256,47 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         hotkeyManager.registerDefaultHotkeys()
 
         hotkeyManager.onPanelHotkey = { [weak self] in
-            // Handle first-run HUD if showing
-            if FirstRunController.shared.isShowingHUD {
-                FirstRunController.shared.hotkeyPressed()
-                return
-            }
-            self?.panelController?.toggle()
+            self?.handlePanelHotkey()
         }
 
         hotkeyManager.onPasteStackHotkey = { [weak self] in
-            self?.activatePasteStack()
+            self?.handlePasteStackHotkey()
         }
 
         hotkeyManager.onQuickPasteHotkey = { [weak self] index in
             self?.quickPaste(index: index)
         }
+    }
+
+    func handlePanelHotkey() {
+        switch Self.panelHotkeyAction(
+            isFirstRunHUDShowing: FirstRunController.shared.isShowingHUD,
+            isPanelVisible: panelController?.isVisible == true
+        ) {
+        case .completeFirstRun:
+            FirstRunController.shared.hotkeyPressed()
+        case .hidePanel:
+            panelController?.hide()
+        case .showPanel:
+            showBottomPanel()
+        }
+    }
+
+    func handlePasteStackHotkey() {
+        pasteService.savePreviousApp()
+        activatePasteStack()
+    }
+
+    static func panelHotkeyAction(isFirstRunHUDShowing: Bool, isPanelVisible: Bool) -> PanelHotkeyAction {
+        if isFirstRunHUDShowing {
+            return .completeFirstRun
+        }
+
+        if isPanelVisible {
+            return .hidePanel
+        }
+
+        return .showPanel
     }
 
     // MARK: - First Run HUD
@@ -257,6 +306,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             // First run completed - open the panel
             self?.showBottomPanel()
         }
+    }
+
+    private func promptForRequiredPermissionsIfNeeded(retryCount: Int = 5) {
+        guard retryCount > 0 else {
+            permissionsService.promptForRequiredPermissionsIfNeeded()
+            return
+        }
+
+        guard !FirstRunController.shared.isShowingHUD else {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
+                self?.promptForRequiredPermissionsIfNeeded(retryCount: retryCount - 1)
+            }
+            return
+        }
+
+        permissionsService.promptForRequiredPermissionsIfNeeded()
     }
 
     // MARK: - Clipboard Monitoring

--- a/Sources/DodoClip/Resources/de.lproj/Localizable.strings
+++ b/Sources/DodoClip/Resources/de.lproj/Localizable.strings
@@ -51,6 +51,11 @@
 "settings.rules" = "Regeln";
 "settings.about" = "Über";
 
+/* Permissions */
+"permissions.accessibility.title" = "Bedienungshilfen für DodoClip aktivieren";
+"permissions.accessibility.message" = "DodoClip benötigt Zugriff auf die Bedienungshilfen, um zur vorherigen App zurückzukehren und den ausgewählten Zwischenablageeintrag einzufügen. Öffnen Sie die Systemeinstellungen und aktivieren Sie DodoClip unter Datenschutz & Sicherheit > Bedienungshilfen. Wenn die App dort bereits aufgeführt war, entfernen Sie sie nach einem Update und fügen Sie sie erneut hinzu.";
+"permissions.openSettings" = "Einstellungen öffnen";
+
 /* General Settings */
 "settings.general.launchAtLogin" = "Bei Anmeldung starten";
 "settings.general.showInMenuBar" = "In Menüleiste anzeigen";

--- a/Sources/DodoClip/Resources/en.lproj/Localizable.strings
+++ b/Sources/DodoClip/Resources/en.lproj/Localizable.strings
@@ -51,6 +51,11 @@
 "settings.rules" = "Rules";
 "settings.about" = "About";
 
+/* Permissions */
+"permissions.accessibility.title" = "Enable Accessibility for DodoClip";
+"permissions.accessibility.message" = "DodoClip needs Accessibility access to return focus to the previous app and paste the selected clip. Open System Settings and enable DodoClip in Privacy & Security > Accessibility. If the app was already listed, remove it and add it again after updating.";
+"permissions.openSettings" = "Open Settings";
+
 /* General Settings */
 "settings.general.launchAtLogin" = "Launch at login";
 "settings.general.showInMenuBar" = "Show in menu bar";

--- a/Sources/DodoClip/Resources/es.lproj/Localizable.strings
+++ b/Sources/DodoClip/Resources/es.lproj/Localizable.strings
@@ -51,6 +51,11 @@
 "settings.rules" = "Reglas";
 "settings.about" = "Acerca de";
 
+/* Permissions */
+"permissions.accessibility.title" = "Activar Accesibilidad para DodoClip";
+"permissions.accessibility.message" = "DodoClip necesita acceso a Accesibilidad para devolver el foco a la app anterior y pegar el elemento seleccionado. Abre Configuración del Sistema y activa DodoClip en Privacidad y seguridad > Accesibilidad. Si la app ya aparecía en la lista, elimínala y vuelve a añadirla después de actualizar.";
+"permissions.openSettings" = "Abrir Configuración";
+
 /* General Settings */
 "settings.general.launchAtLogin" = "Iniciar sesión automáticamente";
 "settings.general.showInMenuBar" = "Mostrar en la barra de menús";

--- a/Sources/DodoClip/Resources/fr.lproj/Localizable.strings
+++ b/Sources/DodoClip/Resources/fr.lproj/Localizable.strings
@@ -51,6 +51,11 @@
 "settings.rules" = "Règles";
 "settings.about" = "À propos";
 
+/* Permissions */
+"permissions.accessibility.title" = "Activer l'accessibilité pour DodoClip";
+"permissions.accessibility.message" = "DodoClip a besoin de l'autorisation Accessibilité pour redonner le focus à l'application précédente et coller l'élément sélectionné. Ouvrez les Réglages Système et activez DodoClip dans Confidentialité et sécurité > Accessibilité. Si l'app figurait déjà dans la liste, supprimez-la puis ajoutez-la de nouveau après la mise à jour.";
+"permissions.openSettings" = "Ouvrir les réglages";
+
 /* General Settings */
 "settings.general.launchAtLogin" = "Lancer au démarrage";
 "settings.general.showInMenuBar" = "Afficher dans la barre des menus";

--- a/Sources/DodoClip/Resources/tr.lproj/Localizable.strings
+++ b/Sources/DodoClip/Resources/tr.lproj/Localizable.strings
@@ -51,6 +51,11 @@
 "settings.rules" = "Kurallar";
 "settings.about" = "Hakkında";
 
+/* Permissions */
+"permissions.accessibility.title" = "DodoClip için Erişilebilirliği Etkinleştir";
+"permissions.accessibility.message" = "DodoClip'in önceki uygulamaya odağı geri verip seçilen öğeyi yapıştırabilmesi için Erişilebilirlik iznine ihtiyacı var. Sistem Ayarları'nı açın ve Gizlilik ve Güvenlik > Erişilebilirlik altında DodoClip'i etkinleştirin. Uygulama burada zaten listeleniyorsa, güncellemeden sonra kaldırıp yeniden ekleyin.";
+"permissions.openSettings" = "Ayarları Aç";
+
 /* General Settings */
 "settings.general.launchAtLogin" = "Girişte başlat";
 "settings.general.showInMenuBar" = "Menü çubuğunda göster";

--- a/Sources/DodoClip/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/DodoClip/Resources/zh-Hans.lproj/Localizable.strings
@@ -51,6 +51,11 @@
 "settings.rules" = "规则";
 "settings.about" = "关于";
 
+/* Permissions */
+"permissions.accessibility.title" = "为 DodoClip 启用辅助功能权限";
+"permissions.accessibility.message" = "DodoClip 需要辅助功能权限，才能将焦点切回之前的应用并粘贴所选内容。请打开系统设置，并在“隐私与安全性 > 辅助功能”中启用 DodoClip。如果更新后列表中已存在该应用，请先移除再重新添加。";
+"permissions.openSettings" = "打开设置";
+
 /* General Settings */
 "settings.general.launchAtLogin" = "登录时启动";
 "settings.general.showInMenuBar" = "在菜单栏中显示";

--- a/Sources/DodoClip/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/DodoClip/Resources/zh-Hant.lproj/Localizable.strings
@@ -51,6 +51,11 @@
 "settings.rules" = "規則";
 "settings.about" = "關於";
 
+/* Permissions */
+"permissions.accessibility.title" = "為 DodoClip 啟用輔助使用權限";
+"permissions.accessibility.message" = "DodoClip 需要輔助使用權限，才能將焦點切回先前的應用程式並貼上所選內容。請打開系統設定，並在「隱私權與安全性 > 輔助使用」中啟用 DodoClip。如果更新後清單中已經有這個 App，請先移除再重新加入。";
+"permissions.openSettings" = "打開設定";
+
 /* General Settings */
 "settings.general.launchAtLogin" = "登入時啟動";
 "settings.general.showInMenuBar" = "在選單列中顯示";

--- a/Sources/DodoClip/Services/PermissionsService.swift
+++ b/Sources/DodoClip/Services/PermissionsService.swift
@@ -1,0 +1,64 @@
+import AppKit
+@preconcurrency import ApplicationServices
+
+enum PermissionsPromptDecision: Equatable {
+    case skip
+    case promptAccessibility
+}
+
+@MainActor
+final class PermissionsService {
+    static let shared = PermissionsService()
+
+    private var hasPromptedThisLaunch = false
+
+    private init() {}
+
+    var isAccessibilityTrusted: Bool {
+        AXIsProcessTrusted()
+    }
+
+    func promptForRequiredPermissionsIfNeeded() {
+        guard Self.permissionsPromptDecision(
+            hasPromptedThisLaunch: hasPromptedThisLaunch,
+            isAccessibilityTrusted: isAccessibilityTrusted
+        ) == .promptAccessibility else {
+            return
+        }
+
+        hasPromptedThisLaunch = true
+
+        let alert = NSAlert()
+        alert.messageText = "Enable Accessibility for DodoClip"
+        alert.informativeText = "DodoClip needs Accessibility access to return focus to the previous app and paste the selected clip. Open System Settings and enable DodoClip in Privacy & Security > Accessibility. If the app was already listed, remove it and add it again after updating."
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "Open Settings")
+        alert.addButton(withTitle: "Later")
+
+        if alert.runModal() == .alertFirstButtonReturn {
+            requestAccessibilityPermission()
+            openAccessibilitySettings()
+        }
+    }
+
+    static func permissionsPromptDecision(hasPromptedThisLaunch: Bool, isAccessibilityTrusted: Bool) -> PermissionsPromptDecision {
+        guard !hasPromptedThisLaunch, !isAccessibilityTrusted else {
+            return .skip
+        }
+
+        return .promptAccessibility
+    }
+
+    private func requestAccessibilityPermission() {
+        let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true] as CFDictionary
+        AXIsProcessTrustedWithOptions(options)
+    }
+
+    private func openAccessibilitySettings() {
+        guard let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility") else {
+            return
+        }
+
+        NSWorkspace.shared.open(url)
+    }
+}

--- a/Sources/DodoClip/Services/PermissionsService.swift
+++ b/Sources/DodoClip/Services/PermissionsService.swift
@@ -29,11 +29,11 @@ final class PermissionsService {
         hasPromptedThisLaunch = true
 
         let alert = NSAlert()
-        alert.messageText = "Enable Accessibility for DodoClip"
-        alert.informativeText = "DodoClip needs Accessibility access to return focus to the previous app and paste the selected clip. Open System Settings and enable DodoClip in Privacy & Security > Accessibility. If the app was already listed, remove it and add it again after updating."
+        alert.messageText = L10n.Permissions.accessibilityTitle
+        alert.informativeText = L10n.Permissions.accessibilityMessage
         alert.alertStyle = .informational
-        alert.addButton(withTitle: "Open Settings")
-        alert.addButton(withTitle: "Later")
+        alert.addButton(withTitle: L10n.Permissions.openSettings)
+        alert.addButton(withTitle: L10n.Settings.later)
 
         if alert.runModal() == .alertFirstButtonReturn {
             requestAccessibilityPermission()

--- a/Sources/DodoClip/Utilities/Localization.swift
+++ b/Sources/DodoClip/Utilities/Localization.swift
@@ -202,6 +202,15 @@ extension L10n {
     }
 }
 
+// MARK: - Permissions
+extension L10n {
+    enum Permissions {
+        static var accessibilityTitle: String { L10n.tr("permissions.accessibility.title") }
+        static var accessibilityMessage: String { L10n.tr("permissions.accessibility.message") }
+        static var openSettings: String { L10n.tr("permissions.openSettings") }
+    }
+}
+
 // MARK: - About
 extension L10n {
     enum About {

--- a/Sources/DodoClip/Views/Panel/BottomPanel.swift
+++ b/Sources/DodoClip/Views/Panel/BottomPanel.swift
@@ -202,9 +202,10 @@ final class BottomPanelController: ObservableObject {
         isVisible = true
     }
 
-    func hide() {
+    func hide(completion: (() -> Void)? = nil) {
         panel?.hide { [weak self] in
             self?.isVisible = false
+            completion?()
         }
     }
 

--- a/Tests/DodoClipTests/DodoClipTests.swift
+++ b/Tests/DodoClipTests/DodoClipTests.swift
@@ -8,4 +8,70 @@ struct DodoClipTests {
         // Basic test to verify the app structure
         #expect(true)
     }
+
+    @MainActor
+    @Test("Panel hotkey completes onboarding before toggling panel")
+    func panelHotkeyPrefersFirstRunHUD() {
+        let action = AppDelegate.panelHotkeyAction(
+            isFirstRunHUDShowing: true,
+            isPanelVisible: true
+        )
+
+        #expect(action == .completeFirstRun)
+    }
+
+    @MainActor
+    @Test("Panel hotkey hides the panel when already visible")
+    func panelHotkeyHidesVisiblePanel() {
+        let action = AppDelegate.panelHotkeyAction(
+            isFirstRunHUDShowing: false,
+            isPanelVisible: true
+        )
+
+        #expect(action == .hidePanel)
+    }
+
+    @MainActor
+    @Test("Panel hotkey shows panel through the capture-aware path")
+    func panelHotkeyShowsHiddenPanel() {
+        let action = AppDelegate.panelHotkeyAction(
+            isFirstRunHUDShowing: false,
+            isPanelVisible: false
+        )
+
+        #expect(action == .showPanel)
+    }
+
+    @MainActor
+    @Test("Permissions prompt appears when accessibility is missing")
+    func permissionsPromptRequiredWhenAccessibilityMissing() {
+        let decision = PermissionsService.permissionsPromptDecision(
+            hasPromptedThisLaunch: false,
+            isAccessibilityTrusted: false
+        )
+
+        #expect(decision == .promptAccessibility)
+    }
+
+    @MainActor
+    @Test("Permissions prompt is skipped after prompting once")
+    func permissionsPromptSkippedAfterPrompting() {
+        let decision = PermissionsService.permissionsPromptDecision(
+            hasPromptedThisLaunch: true,
+            isAccessibilityTrusted: false
+        )
+
+        #expect(decision == .skip)
+    }
+
+    @MainActor
+    @Test("Permissions prompt is skipped when accessibility is already trusted")
+    func permissionsPromptSkippedWhenTrusted() {
+        let decision = PermissionsService.permissionsPromptDecision(
+            hasPromptedThisLaunch: false,
+            isAccessibilityTrusted: true
+        )
+
+        #expect(decision == .skip)
+    }
 }


### PR DESCRIPTION
These changes introduce the prompt for the privacy settings when DodoClip launches.

1. First a popup explaining
<img width="307" height="385" alt="Screenshot 2026-04-02 at 10 06 08" src="https://github.com/user-attachments/assets/93c2a5be-a6f9-4bee-b3f3-a026d59d79b7" />

2. Then a native macOS prompt to open relevant settings page
<img width="489" height="213" alt="Screenshot 2026-04-02 at 10 06 20" src="https://github.com/user-attachments/assets/1abe6969-5c9f-4316-a9f8-00bf7e9a9636" />

3. Privacy > Accessibility settings to enable DodoClip
<img width="807" height="355" alt="Screenshot 2026-04-02 at 10 06 45" src="https://github.com/user-attachments/assets/a64eef57-9213-4386-b939-20b5cedf07e9" />

---

There is also a small fix in the pasting flow to so that direct pasting works reliably (see issue #16).