### PR TITLE
Follow system theme in panel UI

### DIFF
--- a/Sources/DodoClip/Utilities/Theme.swift
+++ b/Sources/DodoClip/Utilities/Theme.swift
@@ -1,29 +1,30 @@
+import AppKit
 import SwiftUI
 
-/// DodoClip theme constants - always dark mode
+/// DodoClip theme constants - automatically follows the system light/dark appearance
 enum Theme {
     // MARK: - Colors
 
     enum Colors {
-        // Panel
-        static let panelBackground = Color(hex: "1E1E1E")
-        static let cardBackground = Color(hex: "2D2D2D")
-        static let cardHover = Color(hex: "3D3D3D")
-        static let cardSelected = Color(hex: "4A4A4A")
+        // Panel - neutrals adapt to the system appearance
+        static let panelBackground = Color(light: "F2F2F7", dark: "1E1E1E")
+        static let cardBackground = Color(light: "FFFFFF", dark: "2D2D2D")
+        static let cardHover = Color(light: "E9E9EF", dark: "3D3D3D")
+        static let cardSelected = Color(light: "DCDCE4", dark: "4A4A4A")
 
         // Text
-        static let textPrimary = Color.white
-        static let textSecondary = Color(hex: "8E8E93")
+        static let textPrimary = Color(light: "000000", dark: "FFFFFF")
+        static let textSecondary = Color(light: "8E8E93", dark: "8E8E93")
 
-        // Accent
+        // Accent - system blue is identical in both appearances
         static let accent = Color(hex: "007AFF")
 
         // UI Elements
-        static let searchBackground = Color(hex: "3A3A3C")
-        static let filterChipBackground = Color(hex: "48484A")
-        static let divider = Color(hex: "38383A")
+        static let searchBackground = Color(light: "E3E3E8", dark: "3A3A3C")
+        static let filterChipBackground = Color(light: "D8D8DD", dark: "48484A")
+        static let divider = Color(light: "D1D1D6", dark: "38383A")
 
-        // Type Badges
+        // Type Badges - vivid system colors, consistent across appearances
         static let badgeText = Color(hex: "007AFF")
         static let badgeImage = Color(hex: "34C759")
         static let badgeLink = Color(hex: "AF52DE")
@@ -121,6 +122,16 @@ extension Color {
         let b = Double(rgb & 0x0000FF) / 255.0
 
         self.init(red: r, green: g, blue: b)
+    }
+
+    /// Creates a dynamic color that resolves to the light or dark hex value
+    /// based on the system appearance at render time.
+    init(light: String, dark: String) {
+        let dynamic = NSColor(name: nil) { appearance in
+            let isDark = appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua
+            return NSColor(hex: isDark ? dark : light) ?? .clear
+        }
+        self.init(nsColor: dynamic)
     }
 }
 

--- a/Sources/DodoClip/Views/Panel/BottomPanel.swift
+++ b/Sources/DodoClip/Views/Panel/BottomPanel.swift
@@ -2,7 +2,7 @@ import AppKit
 import SwiftUI
 
 /// Custom NSPanel for the bottom clipboard panel
-/// Floats above all windows, no title bar, dark appearance
+/// Floats above all windows, no title bar, follows the system light/dark appearance
 final class BottomPanel: NSPanel {
 
     private var hostingController: NSHostingController<AnyView>?
@@ -41,9 +41,11 @@ final class BottomPanel: NSPanel {
         isMovableByWindowBackground = false
         acceptsMouseMovedEvents = true
 
-        // Visual effect for the background
+        // Visual effect for the background.
+        // `.popover` adapts its vibrancy to the active light/dark appearance,
+        // unlike `.hudWindow` which is always dark.
         let visualEffect = NSVisualEffectView()
-        visualEffect.material = .hudWindow
+        visualEffect.material = .popover
         visualEffect.state = .active
         visualEffect.blendingMode = .behindWindow
         visualEffect.wantsLayer = true


### PR DESCRIPTION
Closes #23. The panel UI was hardcoded to dark mode. It now automatically adapts to the macOS system appearance, switching between light and dark in real time as the user changes their system setting.

## Changes
- `Theme.Colors` neutrals (panel, card, text, search, filter, divider) are now dynamic colors with distinct light and dark variants, resolved per the active `NSAppearance` at render time.
- Added a `Color(light:dark:)` initializer backed by a dynamic `NSColor` provider so all existing call sites need no changes.
- `BottomPanel`'s `NSVisualEffectView` material switched from `.hudWindow` (always dark) to `.popover`, which adapts its vibrancy to the system appearance.
- Accent and type-badge colors stay constant across appearances, matching standard system color behavior.

## Benefits
- The panel and menu bar popover blend with the user's chosen system theme.
- Appearance changes are reflected live without restarting the app.
- No call-site churn: all existing `Theme.Colors` references keep working.

## Testing
- `swift build` succeeds; all 7 tests pass.
- Manual: toggle macOS appearance with the panel open and confirm it switches live; verify card text and badges stay legible in light mode across the bottom panel and menu bar popover.